### PR TITLE
Declare arm64 support, bump version

### DIFF
--- a/installer_package/installer_package.pkgproj
+++ b/installer_package/installer_package.pkgproj
@@ -542,7 +542,7 @@
 				<key>USE_HFS+_COMPRESSION</key>
 				<false/>
 				<key>VERSION</key>
-				<string>3.1.1</string>
+				<string>3.1.2</string>
 			</dict>
 			<key>TYPE</key>
 			<integer>0</integer>
@@ -731,6 +731,14 @@
 		</dict>
 		<key>PROJECT_SETTINGS</key>
 		<dict>
+			<key>ADVANCED_OPTIONS</key>
+			<dict>
+				<key>installer-script.options:hostArchitectures</key>
+				<array>
+					<string>x86_64</string>
+					<string>arm64</string>
+				</array>
+			</dict>
 			<key>BUILD_FORMAT</key>
 			<integer>0</integer>
 			<key>BUILD_PATH</key>


### PR DESCRIPTION
Added declaration for arm64 supports to the Distribution.xml file of the package installer so it will install on Apple Silicon Macs without prompting for Rosetta installation first.

Bumped the version to 3.1.2.